### PR TITLE
Add ability to query LogSet by Name

### DIFF
--- a/logset.go
+++ b/logset.go
@@ -57,7 +57,8 @@ func (l *LogSetClient) Create(createRequest LogSetCreateRequest) (*LogSet, error
 }
 
 type LogSetReadRequest struct {
-	Key string
+	Key  string
+	Name string
 }
 
 type LogSetReadResponse struct {
@@ -74,6 +75,8 @@ func (l *LogSetClient) Read(readRequest LogSetReadRequest) (*LogSet, error) {
 
 	for _, logSet := range response.LogSets {
 		if logSet.Key == readRequest.Key {
+			return &logSet, nil
+		} else if logSet.Name == readRequest.Name {
 			return &logSet, nil
 		}
 	}


### PR DESCRIPTION
We'd like to be able to find a specific LogSet when we only know its Name (eg. we want to find LogSet Key / ID when we only know Name).

Our specific use-case is as following:
- we want to be able to create Logentries Logs under already existing Logentries LogSet via Terraform (utilising Terraform Logentries Provider)
- at the moment Terraform Logentries Provider exposes LogSet ID (Key) attribute only if LogSet was created via Terraform
- we want to extend Terraform Logentries provider with a LogSet datasource which will expose the ID / Name

In order to be able to do that we first need ability to lookup LogSet via its Name in the `le_goclient` library - hence this PR :-)

Let me know whether there's anything else I need to add / tweak.